### PR TITLE
Change Centos to CentOS

### DIFF
--- a/extension-files/postinstall
+++ b/extension-files/postinstall
@@ -2,7 +2,7 @@
 
 THE_INCLUDE="Include=/usr/share/zabbix-agent-extensions/include.d/"
 
-if (grep -q -P "Ubuntu|Debian|Centos|Raspbian" /etc/os-release);then
+if (grep -q -P "Ubuntu|Debian|CentOS|Raspbian" /etc/os-release);then
 
    if [ -e "/etc/zabbix/zabbix_agentd.d/zabbix-agent-extensions" ];
    then


### PR DESCRIPTION
In /etc/os-release on CentOS 7 & 8 name is CentOS not Centos