### PR TITLE
Update zabbix_check_puppetstate to support state file location for Puppet 7

### DIFF
--- a/extension-files/tools/zabbix_check_puppetstate
+++ b/extension-files/tools/zabbix_check_puppetstate
@@ -20,6 +20,7 @@ import sys
 import re
 
 possible_state_files = [
+    "/opt/puppetlabs/puppet/public/last_run_summary.yaml",
     "/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml",
     "/var/lib/puppet/state/last_run_summary.yaml"
 ]


### PR DESCRIPTION
As per the release notes of Puppet7, the location of the statefile is moving (see https://puppet.com/blog/whats-new-in-puppet-7-platform/):

"The default location of the newly added publicdir is /opt/puppetlabs/puppet/public on Linux and C:\ProgramData\PuppetLabs\puppet\public on Microsoft Windows. The directory is world-readable and has become the default location for the last_run_summary.yaml file."