### PR TITLE
Execute ntp tools and smartctl in chroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ It is based on the offical [image](https://hub.docker.com/r/zabbix/zabbix-agent)
    * Adapt the file to your own needs, see [environment variables](https://hub.docker.com/r/zabbix/zabbix-agent)
     * Configure `ZBX_ACTIVESERVER`
     * Configure `ZBX_PASSIVESERVERS`
+    * Configure `ZABBIX_EXTENTIONS_OS_TOOLS_CHROOT` to the path wher your hostfs is mounted (typically /rootfs)
     * Configure the version of the image [check dockerhub](https://hub.docker.com/repository/docker/scoopex666/zabbix-agent-with-agent-extensions)
    * Apply deployment
      ```

--- a/extension-files/tools/zabbix_check_ntp
+++ b/extension-files/tools/zabbix_check_ntp
@@ -40,7 +40,7 @@ def check_ntpd(what):
     #
 
     server_count = 0
-    cmd = "ntpq -n -c peers"
+    cmd = f"chroot {get_root()} ntpq -n -c peers"
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     out, err = process.communicate()
     for line in out.decode('utf8').splitlines():
@@ -93,7 +93,7 @@ def check_chronyc(what):
     server_count = 0
 
     if what == "count":
-        cmd = "chronyc -c sources"
+        cmd = f"chroot {get_root()} chronyc -c sources"
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = process.communicate()
         for line in out.decode('utf8').splitlines():
@@ -105,7 +105,7 @@ def check_chronyc(what):
             server_count += 1
         sys.stdout.write(str(server_count))
     else:
-        cmd = "chronyc -c tracking"
+        cmd = f"chroot {get_root()} chronyc -c tracking"
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = process.communicate()
         for line in out.decode('utf8').splitlines():
@@ -158,7 +158,7 @@ def check_systemd(what):
         sys.stdout.write(str(server_count))
         return
 
-    cmd = "timedatectl show-timesync"
+    cmd = f"chroot {get_root()} timedatectl show-timesync"
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     out, err = process.communicate()
     for line in out.decode('utf8').splitlines():
@@ -182,6 +182,20 @@ def check_systemd(what):
             elif what == "offset" and k == "RootDispersion":
                 sys.stdout.write(convert_time_systemd(v))
 
+def get_root():
+  return os.environ.get("ZABBIX_EXTENTIONS_OS_TOOLS_CHROOT", "/")
+
+def which(tool: str):
+  result = subprocess.run(
+      ["chroot", get_root(), "which", tool],
+      capture_output=True,
+      text=True
+  )
+  if result.returncode == 0:
+    return True
+  else:
+    return False
+
 
 if len(sys.argv) != 2:
     print(sys.argv[0] + " offset|jitter|delay|count")
@@ -189,11 +203,11 @@ if len(sys.argv) != 2:
 
 what = sys.argv[1]
 
-if shutil.which("ntpq"):
+if which("ntpq"):
     check_ntpd(what)
-elif shutil.which("chronyc"):
+elif which("chronyc"):
     check_chronyc(what)
-elif shutil.which("timedatectl"):
+elif which("timedatectl"):
     check_systemd(what)
 else:
     print("No ntp client implementation found", file=sys.stderr)

--- a/extension-files/tools/zabbix_check_smartmontools
+++ b/extension-files/tools/zabbix_check_smartmontools
@@ -13,6 +13,10 @@ import stat
 #### HELPERS
 
 
+def get_root():
+  return os.environ.get("ZABBIX_EXTENTIONS_OS_TOOLS_CHROOT", "/")
+
+
 def is_device(dev):
 
     m = re.match(r"^([a-zA-Z0-9]+)([\sa-zA-Z0-9,-_\/]+)?$", dev)
@@ -33,8 +37,7 @@ def get_health(device):
         sys.stderr.write("%s :: get_health :: FAILED - device >>%s<< does not exist\n" % (__file__, device))
         return
 
-    cmd = "smartctl -H /dev/%s" % device
-    print(cmd)
+    cmd = f"chroot {get_root()} smartctl -H /dev/{device}"
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     out, err = process.communicate()
 
@@ -57,7 +60,7 @@ def get_attribute(device, attribute):
         sys.stderr.write("%s :: get_health :: FAILED - device >>%s<< does not exist\n" % (__file__, device))
         return
 
-    cmd = "smartctl -A /dev/%s" % device
+    cmd = f"chroot {get_root()} smartctl -A /dev/{device}"
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     out, err = process.communicate()
     result = None
@@ -81,7 +84,7 @@ def get_info(device, info):
         sys.stderr.write("%s :: get_health :: FAILED - device >>%s<< does not exist\n" % (__file__, device))
         return
 
-    cmd = "smartctl -i /dev/%s" % device
+    cmd = f"chroot {get_root()} smartctl -i /dev/{device}"
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     out, err = process.communicate()
     result = None

--- a/kubernetes/zabbix-agent-daemonset-kubernetes.yaml
+++ b/kubernetes/zabbix-agent-daemonset-kubernetes.yaml
@@ -37,6 +37,8 @@ spec:
           securityContext:
             privileged: true
           env:
+            - name: ZABBIX_EXTENTIONS_OS_TOOLS_CHROOT
+              value: "/rootfs"
             - name: ZBX_METADATA
               value: "kubernetes-node"
             - name: ZBX_HOSTNAME

--- a/kubernetes/zabbix-agent2-daemonset-kubernetes-release.yaml
+++ b/kubernetes/zabbix-agent2-daemonset-kubernetes-release.yaml
@@ -37,6 +37,8 @@ spec:
           securityContext:
             privileged: true
           env:
+            - name: ZABBIX_EXTENTIONS_OS_TOOLS_CHROOT
+              value: "/rootfs"
             - name: ZBX_METADATA
               value: "kubernetes-node"
             - name: ZBX_HOSTNAME

--- a/kubernetes/zabbix-agent2-daemonset-kubernetes.yaml
+++ b/kubernetes/zabbix-agent2-daemonset-kubernetes.yaml
@@ -37,6 +37,8 @@ spec:
           securityContext:
             privileged: true
           env:
+            - name: ZABBIX_EXTENTIONS_OS_TOOLS_CHROOT
+              value: "/rootfs"
             - name: ZBX_METADATA
               value: "kubernetes-node"
             - name: ZBX_HOSTNAME


### PR DESCRIPTION
- The environment variable ZABBIX_EXTENTIONS_OS_TOOLS_CHROOT specifies the chroot in whichn the command is executed
- This is needed for container deployments