### PR TITLE
Add path used by debian package for puppet agent

### DIFF
--- a/extension-files/tools/zabbix_check_puppetstate
+++ b/extension-files/tools/zabbix_check_puppetstate
@@ -22,7 +22,8 @@ import re
 possible_state_files = [
     "/opt/puppetlabs/puppet/public/last_run_summary.yaml",
     "/opt/puppetlabs/puppet/cache/state/last_run_summary.yaml",
-    "/var/lib/puppet/state/last_run_summary.yaml"
+    "/var/lib/puppet/state/last_run_summary.yaml",
+    "/var/cache/puppet/public/last_run_summary.yaml"
 ]
 
 possible_run_report = [


### PR DESCRIPTION
Puppet agent shipped in Debian official repositories installs the last_run_summary.yaml in /var/cache/puppet/public/ by default which was not present in the possible_state_files